### PR TITLE
feat: Intercept CONFIRM_INSTALL from session install

### DIFF
--- a/app/src/main/java/io/github/chimio/inxlocker/util/IntentAnalyzer.kt
+++ b/app/src/main/java/io/github/chimio/inxlocker/util/IntentAnalyzer.kt
@@ -14,20 +14,22 @@ object IntentAnalyzer {
             val TAG = "IntentAnalyzer"
             val original = IntentSnapshot.capture(intent)
 
-            YLog.d(TAG,"Intent action: ${original.action}")
-            YLog.d(TAG,"Intent component: ${original.component}")
-            YLog.d(TAG,"package: ${original.packageName}")
-            YLog.d(TAG,"Intent type: ${intent.type}")
-            YLog.d(TAG,"Intent data: ${intent.data}")
-            YLog.d(TAG,"Intent clipData: ${intent.clipData}")
+            YLog.d(TAG, "Intent action: ${original.action}")
+            YLog.d(TAG, "Intent component: ${original.component}")
+            YLog.d(TAG, "package: ${original.packageName}")
+            YLog.d(TAG, "Intent type: ${intent.type}")
+            YLog.d(TAG, "Intent data: ${intent.data}")
+            YLog.d(TAG, "Intent clipData: ${intent.clipData}")
 
             if (mimeTypeFromIntent(intent) || hasValidAction(intent) || mimeTypeFromCIntentData(intent)) {
                 if (!hasSpecificComponent(intent)) {
-                    if (intent.action == Intent.ACTION_DELETE) {
-                        if (PrefsProvider.getBoolean("intercept_uninstall", false)) {
-                            return Result.ShouldRedirect
+                    if (intent.action == Intent.ACTION_DELETE ||
+                        intent.action == Intent.ACTION_UNINSTALL_PACKAGE
+                    ) {
+                        return if (PrefsProvider.getBoolean("intercept_uninstall", false)) {
+                            Result.ShouldRedirect
                         } else {
-                            return Result.ShouldNotRedirect
+                            Result.ShouldNotRedirect
                         }
                     }
                     return Result.ShouldRedirect
@@ -41,18 +43,21 @@ object IntentAnalyzer {
 
     private fun hasValidAction(intent: Intent): Boolean {
         return intent.action in listOf(
-            "android.intent.action.INSTALL_PACKAGE",
+            Intent.ACTION_INSTALL_PACKAGE,
             "android.content.pm.action.CONFIRM_INSTALL",
-            Intent.ACTION_DELETE)
+            Intent.ACTION_UNINSTALL_PACKAGE,
+            Intent.ACTION_DELETE
+        )
     }
 
     private fun mimeTypeFromIntent(intent: Intent): Boolean {
         return intent.type == "application/vnd.android.package-archive"
     }
-//字符串分析大法，不优雅，但是好像没什么问题
+
+    //字符串分析大法，不优雅，但是好像没什么问题
     private fun mimeTypeFromCIntentData(intent: Intent): Boolean {
         val uri = intent.data.toString()
-        return (uri.endsWith(".apk") || uri.endsWith(".apks")|| uri.endsWith(".apk.1")) &&
+        return (uri.endsWith(".apk") || uri.endsWith(".apks") || uri.endsWith(".apk.1")) &&
                 (uri.startsWith("file://") || uri.startsWith("content://"))
     }
 

--- a/app/src/main/java/io/github/chimio/inxlocker/util/IntentRedirector.kt
+++ b/app/src/main/java/io/github/chimio/inxlocker/util/IntentRedirector.kt
@@ -13,6 +13,7 @@ object IntentRedirector {
     }
 
     private const val ACTION_INSTALL_PACKAGE = "android.intent.action.INSTALL_PACKAGE"
+    private const val ACTION_UNINSTALL_PACKAGE = Intent.ACTION_UNINSTALL_PACKAGE
     private const val ACTION_DELETE = Intent.ACTION_DELETE
     private const val TAG = "InstallerRedirect"
 
@@ -39,7 +40,7 @@ object IntentRedirector {
     private fun normalizeAction(intent: Intent) {
         when {
             intent.action == ACTION_INSTALL_PACKAGE -> intent.action = Intent.ACTION_VIEW
-            intent.action == ACTION_DELETE -> {
+            intent.action == ACTION_DELETE || intent.action == ACTION_UNINSTALL_PACKAGE -> {
                 YLog.i(TAG, "拦截卸载Intent，重定向到指定安装器")
             }
             intent.action.isNullOrEmpty() -> intent.action = Intent.ACTION_VIEW
@@ -50,7 +51,7 @@ object IntentRedirector {
         YLog.i(tag, "Intent重定向:")
         YLog.i(tag, "- 目标 package: ${current.`package` ?: "<系统默认>"}")
         YLog.i(tag, "- Intent action: ${current.action}")
-        if (current.action == ACTION_DELETE) {
+        if (current.action == ACTION_DELETE || current.action == ACTION_UNINSTALL_PACKAGE) {
             YLog.i(tag, "- 拦截卸载Intent，重定向到指定安装器")
         }
     }


### PR DESCRIPTION
By adding the `android.content.pm.action.CONFIRM_INSTALL` action, the app can now intercept installation confirmations initiated by the system PackageInstaller API.