### PR TITLE
feat: add support for Android 8/9

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,7 +13,7 @@ android {
 
     defaultConfig {
         applicationId = "io.github.chimio.inxlocker"
-        minSdk = 29
+        minSdk = 26
         targetSdk = 36
         versionCode = 11
         versionName = "1.4"

--- a/app/src/main/java/io/github/chimio/inxlocker/hook/HookEntry.kt
+++ b/app/src/main/java/io/github/chimio/inxlocker/hook/HookEntry.kt
@@ -146,36 +146,59 @@ class HookEntry : IYukiHookXposedInit {
     }
 
     fun PackageParam.hookActivityStarterExecute() {
-        "com.android.server.wm.ActivityStarter".toClassOrNull()?.apply {
-            resolve().firstMethod {
-                name = "execute"
-            }.hook {
-                before {
-                    try {
-                        PrefsProvider.reload()
-                        val mRequestField = instanceClass?.getDeclaredField("mRequest")
-                            ?.apply { isAccessible = true }
-                            ?: throw NoSuchFieldException("mRequest field not found")
+        val targetClass =
+            if (Build.VERSION.SDK_INT >= 29) "com.android.server.wm.ActivityStarter" else "com.android.server.am.ActivityStarter"
+        targetClass.toClassOrNull()?.apply {
+            if (Build.VERSION.SDK_INT >= 28) {
+                resolve().firstMethod {
+                    name = "execute"
+                }.hook {
+                    before {
+                        try {
+                            PrefsProvider.reload()
+                            val mRequestField = instanceClass?.getDeclaredField("mRequest")
+                                ?.apply { isAccessible = true }
+                                ?: throw NoSuchFieldException("mRequest field not found")
 
-                        val requestObject = mRequestField.get(instance)
-                            ?: throw NullPointerException("Request object is null")
+                            val requestObject = mRequestField.get(instance)
+                                ?: throw NullPointerException("Request object is null")
 
-                        val requestClass =
-                            "com.android.server.wm.ActivityStarter\$Request".toClassOrNull()
-                                ?: throw NullPointerException("ActivityStarter\$Request class not found")
+                            val requestClass =
+                                "${targetClass}\$Request".toClassOrNull()
+                                    ?: throw NullPointerException("ActivityStarter\$Request class not found")
 
-                        val intentField = requestClass.getDeclaredField("intent")
-                            .apply { isAccessible = true }
+                            val intentField = requestClass.getDeclaredField("intent")
+                                .apply { isAccessible = true }
 
-                        val intent = intentField.get(requestObject) as? Intent
+                            val intent = intentField.get(requestObject) as? Intent
 
-                        handleIntentIfNeeded(intent, "ActivityStarter.execute") {
-                            intent?.let { modifiedIntent ->
-                                intentField.set(requestObject, modifiedIntent)
+                            handleIntentIfNeeded(intent, "ActivityStarter.execute") {
+                                intent?.let { modifiedIntent ->
+                                    intentField.set(requestObject, modifiedIntent)
+                                }
                             }
+                        } catch (e: Exception) {
+                            YLog.e(TAG, "ActivityStarter.execute Hook 错误: ${e.message}", e)
                         }
-                    } catch (e: Exception) {
-                        YLog.e(TAG, "ActivityStarter.execute Hook 错误: ${e.message}", e)
+                    }
+                }
+            } else {
+                resolve().firstMethod {
+                    name = "startActivityMayWait"
+                }.hook {
+                    before {
+                        try {
+                            PrefsProvider.reload()
+                            val intentIndex = args.indexOfFirst { it is Intent }
+                            if (intentIndex != -1) {
+                                val intent = args(intentIndex).cast<Intent>()
+                                handleIntentIfNeeded(intent, "ActivityStarter.startActivityMayWait"){
+                                    args(intentIndex).set(intent)
+                                }
+                            }
+                        } catch (e: Exception) {
+                            YLog.e(TAG, "ActivityStarter.startActivityMayWait Hook 错误: ${e.message}", e)
+                        }
                     }
                 }
             }

--- a/app/src/main/java/io/github/chimio/inxlocker/util/IntentAnalyzer.kt
+++ b/app/src/main/java/io/github/chimio/inxlocker/util/IntentAnalyzer.kt
@@ -36,7 +36,8 @@ object IntentAnalyzer {
                         Result.ShouldNotRedirect
                     }
                 }
-                "android.content.pm.action.CONFIRM_INSTALL" -> {
+                "android.content.pm.action.CONFIRM_INSTALL",
+                "android.content.pm.action.CONFIRM_PERMISSIONS" -> {
                     if (PrefsProvider.getBoolean("intercept_session_install", false)) {
                         Result.ShouldRedirect
                     } else {
@@ -63,6 +64,7 @@ object IntentAnalyzer {
         return intent.action in listOf(
             Intent.ACTION_INSTALL_PACKAGE,
             "android.content.pm.action.CONFIRM_INSTALL",
+            "android.content.pm.action.CONFIRM_PERMISSIONS",
             Intent.ACTION_UNINSTALL_PACKAGE,
             Intent.ACTION_DELETE
         )
@@ -93,6 +95,7 @@ object IntentAnalyzer {
         Intent.ACTION_VIEW,
         Intent.ACTION_INSTALL_PACKAGE,
         "android.content.pm.action.CONFIRM_INSTALL",
+        "android.content.pm.action.CONFIRM_PERMISSIONS",
         Intent.ACTION_UNINSTALL_PACKAGE,
         Intent.ACTION_DELETE
     )


### PR DESCRIPTION
- Update `hookActivityStarterExecute` to support older Android versions:
    - Target `com.android.server.am.ActivityStarter` on versions below Android 10.
    - Hook `startActivityMayWait` for Android 8/8.1 instead of the `execute` method used in Android 9+.
- Add `CONFIRM_PERMISSIONS` to `IntentAnalyzer` to support intercepting install sessions on Android 8/9.
- Lower minSdk from 29 to 26.

Resolves #10