### PR TITLE
refactor: improve Intent redirection logic and constant management

### DIFF
--- a/app/src/main/java/io/github/chimio/inxlocker/util/IntentAnalyzer.kt
+++ b/app/src/main/java/io/github/chimio/inxlocker/util/IntentAnalyzer.kt
@@ -4,13 +4,16 @@ import android.content.Intent
 import com.highcapable.yukihookapi.hook.log.YLog
 
 object IntentAnalyzer {
+    private const val TAG = "IntentAnalyzer"
+    private const val INTENT_ACTION_CONFIRM_INSTALL = "android.content.pm.action.CONFIRM_INSTALL"
+    private const val INTENT_ACTION_CONFIRM_PERMISSIONS = "android.content.pm.action.CONFIRM_PERMISSIONS"
 
     sealed class Result {
         object ShouldRedirect : Result()
         object ShouldNotRedirect : Result()
     }
+
     fun analyze(intent: Intent): Result = runCatching {
-        val TAG = "IntentAnalyzer"
         val original = IntentSnapshot.capture(intent)
 
         YLog.d(TAG, "Intent action: ${original.action}")
@@ -42,14 +45,16 @@ object IntentAnalyzer {
                         Result.ShouldNotRedirect
                     }
                 }
-                "android.content.pm.action.CONFIRM_INSTALL",
-                "android.content.pm.action.CONFIRM_PERMISSIONS" -> {
+
+                INTENT_ACTION_CONFIRM_INSTALL,
+                INTENT_ACTION_CONFIRM_PERMISSIONS -> {
                     if (PrefsProvider.getBoolean("intercept_session_install", false)) {
                         Result.ShouldRedirect
                     } else {
                         Result.ShouldNotRedirect
                     }
                 }
+
                 else -> Result.ShouldRedirect
             }
         } ?: Result.ShouldNotRedirect
@@ -69,8 +74,8 @@ object IntentAnalyzer {
     private fun hasValidAction(intent: Intent): Boolean {
         return intent.action in listOf(
             Intent.ACTION_INSTALL_PACKAGE,
-            "android.content.pm.action.CONFIRM_INSTALL",
-            "android.content.pm.action.CONFIRM_PERMISSIONS",
+            INTENT_ACTION_CONFIRM_INSTALL,
+            INTENT_ACTION_CONFIRM_PERMISSIONS,
             Intent.ACTION_UNINSTALL_PACKAGE,
             Intent.ACTION_DELETE
         )
@@ -100,8 +105,8 @@ object IntentAnalyzer {
     private val allowedActions = listOf(
         Intent.ACTION_VIEW,
         Intent.ACTION_INSTALL_PACKAGE,
-        "android.content.pm.action.CONFIRM_INSTALL",
-        "android.content.pm.action.CONFIRM_PERMISSIONS",
+        INTENT_ACTION_CONFIRM_INSTALL,
+        INTENT_ACTION_CONFIRM_PERMISSIONS,
         Intent.ACTION_UNINSTALL_PACKAGE,
         Intent.ACTION_DELETE
     )

--- a/app/src/main/java/io/github/chimio/inxlocker/util/IntentRedirector.kt
+++ b/app/src/main/java/io/github/chimio/inxlocker/util/IntentRedirector.kt
@@ -59,19 +59,31 @@ object IntentRedirector {
     }
 
     private fun applyRedirection(intent: Intent) {
+        val isUninstall = intent.action == ACTION_DELETE || intent.action == ACTION_UNINSTALL_PACKAGE
         val targetPackage = getTargetPackageForIntent(intent)
+
         if (!targetPackage.isNullOrBlank()) {
-            val forcedComponent = getForcedComponentForPackage(targetPackage)
-            if (forcedComponent != null) {
-                intent.component = forcedComponent
-                intent.`package` = null
-            } else {
+            if (isUninstall) {
+                // Clear component and only set the target package for uninstall scenarios
+                // The target app will handle the ACTION_DELETE routing automatically
                 intent.component = null
                 intent.setPackage(targetPackage)
+            } else {
+                // For installation, check if a specific component is forced by the user
+                val forcedComponent = getForcedComponentForPackage(targetPackage)
+                if (forcedComponent != null) {
+                    intent.component = forcedComponent
+                    intent.`package` = null
+                } else {
+                    intent.component = null
+                    intent.setPackage(targetPackage)
+                }
             }
+            // Add necessary flags for redirection
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_GRANT_READ_URI_PERMISSION)
         } else {
-            if (intent.action == ACTION_DELETE || intent.action == ACTION_UNINSTALL_PACKAGE) {
+            // If no specific target package is set, ensure system default handles it cleanly
+            if (isUninstall) {
                 intent.component = null
                 intent.`package` = null
             }


### PR DESCRIPTION
- Clean up `IntentAnalyzer` by moving the `TAG` to a class-level constant and improving code structure
- Refactor `IntentAnalyzer` to use constants for system install and permission confirmation actions
- Improve `IntentRedirector` logic to handle uninstallation intents more cleanly by prioritizing package setting over forced components
- Ensure appropriate flags are added during intent redirection